### PR TITLE
Export a method for instantiating a logger which is not tracked in th…

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -89,6 +89,13 @@ module.exports = {
         return logger;
     },
     /**
+     * Creates a new Logger, without keeping track of it in the loggers list
+     * @arguments the same as Logger constructor
+     */
+    getUntrackedLogger: function(id, transports, options) {
+        return new Logger(curLevel, id, transports, options);
+    },
+    /**
      * Changes the log level for the existing loggers by id.
      * @param level the new log level.
      * @param id if specified the level will be changed only for loggers with the


### PR DESCRIPTION
…e list of available logger

One use case where this is needed is for tracking request ids in a REST nodejs service. There, for each request, we instantiate a new logger which will have as an id the requestId. Afterwards, that logger will be used in all the functions which are called as part of that request context. Storing the logger for each request will translate in memory filling up.