### PR TITLE
refactor: replace deprecated String.prototype.substr()

### DIFF
--- a/lib/Logger.js
+++ b/lib/Logger.js
@@ -101,10 +101,10 @@ function getCallerInfo() {
         //Firefox && Safari
         if(stack[2].indexOf("log@") === 0){
             //Safari
-            callerInfo.methodName = stack[3].substr(0, stack[3].indexOf("@"));
+            callerInfo.methodName = stack[3].substring(0, stack[3].indexOf("@"));
         } else {
             //Firefox
-            callerInfo.methodName = stack[2].substr(0, stack[2].indexOf("@"));
+            callerInfo.methodName = stack[2].substring(0, stack[2].indexOf("@"));
         }
         return callerInfo;
     }


### PR DESCRIPTION
[String.prototype.substr()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr) is deprecated so we replace it with [String.prototype.substring()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substring) which works similarily but isn't deprecated.
.substr() probably isn't going away anytime soon but the change is trivial so it doesn't hurt to do it.