### PR TITLE
Pin GitHub Actions to SHA hashes

### DIFF
--- a/.github/workflows/autopublish.yml
+++ b/.github/workflows/autopublish.yml
@@ -12,12 +12,12 @@ jobs:
 
     steps:
       - name: "Checkout source code"
-        uses: "actions/checkout@v5"
+        uses: "actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd"  # v5
       - name: "Automated Release"
-        uses: "phips28/gh-action-bump-version@master"
+        uses: "phips28/gh-action-bump-version@215e27a882516826c59df7f09da8c67d5f375cbd"  # master
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - uses: actions/setup-node@v5
+      - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444  # v5
         with:
           node-version: 'lts/*'
           registry-url: 'https://registry.npmjs.org'


### PR DESCRIPTION
Pin all GitHub Actions version tags to their corresponding commit SHA hashes for improved supply-chain security.

Original version tags are preserved as comments (e.g. `# v4`).