### PR TITLE
ci(bump): only escalate the package version on deliberate markers

### DIFF
--- a/.github/workflows/autopublish.yml
+++ b/.github/workflows/autopublish.yml
@@ -15,6 +15,14 @@ jobs:
         uses: "actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd"  # v5
       - name: "Automated Release"
         uses: "phips28/gh-action-bump-version@215e27a882516826c59df7f09da8c67d5f375cbd"  # master
+        with:
+          # The action's default word lists substring-match 'major'/'minor'/
+          # 'feat' anywhere in the commit message — dependabot commit footers
+          # escalated jitsi/js-utils from 6.3.2 to 12.0.0 that way, and any
+          # prose containing e.g. 'feature' would do the same here. React
+          # only to deliberate markers.
+          major-wording: 'BREAKING CHANGE'
+          minor-wording: 'feat:,feat('
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444  # v5


### PR DESCRIPTION
## Summary

The `phips28/gh-action-bump-version` defaults substring-match its escalation words (`major`, `minor`, `feat`) anywhere in the commit message. That's what escalated `@jitsi/js-utils` from 6.3.2 to 12.0.0 (and earlier from 2.8.2 to 6.0.0): dependabot commit footers of the form `update-type: version-update:semver-<level>` matched the defaults (fixed in jitsi/js-utils#149). This repo runs the same action with the default word lists, so any commit message containing those substrings anywhere — e.g. the word "feature" in prose — silently publishes an escalated version.

This sets explicit word lists: a breaking release now requires the standard uppercase `BREAKING CHANGE` conventional-commits footer in the commit body, and a semver-middle release requires a conventional `feat:`/`feat(` prefix. Everything else lands as a patch release.

## Test plan

- YAML validated locally.
- Identical change already merged and verified in jitsi/js-utils#149 — the merge there produced the expected patch bump (12.0.3 → 12.0.4).
- The commit message of this PR deliberately avoids both the old and the new trigger words, so its merge should produce a patch bump. On `push`, GitHub runs the workflow file from the pushed commit, so the new word lists apply immediately.

> Merge note: please rebase-merge keeping the commit message as-is.
